### PR TITLE
Add an option to use the image from Silcer Thumbnails plugin

### DIFF
--- a/octoprint_rtmpstreamer/__init__.py
+++ b/octoprint_rtmpstreamer/__init__.py
@@ -22,6 +22,7 @@ import shlex
 import shutil
 import subprocess
 import flask
+import re
 
 import octoprint.server.util.flask
 from octoprint.server import admin_permission, NO_CONTENT
@@ -415,7 +416,7 @@ class rtmpstreamer(octoprint.plugin.BlueprintPlugin,
         fileInfo = current_data["job"]["file"]
         filename = "None Loaded"
         if fileInfo["name"]:
-            filename = fileInfo["name"].replace(".gcode", "")
+            filename = re.sub(r"\.gcod?e?$", "", fileInfo["name"], flags=re.IGNORECASE)
 
         estimatedPrintTime = current_data["job"]["estimatedPrintTime"]
 

--- a/octoprint_rtmpstreamer/__init__.py
+++ b/octoprint_rtmpstreamer/__init__.py
@@ -444,16 +444,17 @@ class rtmpstreamer(octoprint.plugin.BlueprintPlugin,
             elif overlay_style == "wm_tl":
                 img.paste(watermark, (padding, padding))
 
-        if 'prusaslicerthumbnails' in self._plugin_manager.plugins and self._settings.get(["include_thumb"]):
-            if os.path.exists(os.path.join(self._settings.global_get_basefolder("data"), "prusaslicerthumbnails", filename + ".png")):
-                thumb = Image.open(os.path.join(self._settings.global_get_basefolder("data"), "prusaslicerthumbnails", filename + ".png"))
+        if 'prusaslicerthumbnails' in self._plugin_manager.plugins and self._settings.get_boolean(["include_thumb"]):
+            thumbfile = os.path.join(self._settings.global_get_basefolder("data"), "prusaslicerthumbnails", filename + ".png")
+            if os.path.exists(thumbfile):
+                thumb = Image.open(thumbfile)
                 th_w = self._settings.get(["thumbw"])
                 th_h = self._settings.get(["thumbh"])
                 newsize = (int(th_w), int(th_h))
                 thumb = thumb.resize(newsize)
                 th_x = int(self._settings.get(["thumbx"]))
                 th_y = int(self._settings.get(["thumby"]))
-                img.paste(thumb, (th_x, th_y))
+                img.paste(thumb, (th_x, th_y), thumb)
 
         draw = ImageDraw.Draw(img)
 

--- a/octoprint_rtmpstreamer/templates/rtmpstreamer_settings.jinja2
+++ b/octoprint_rtmpstreamer/templates/rtmpstreamer_settings.jinja2
@@ -135,7 +135,7 @@
                         <div class="controls">
                             <div class="input-prepend input-append">
                                 <button class="btn icon-plus" data-bind="click: uploadImage"></button>
-                                <select data-bind="options: overlay_files, value: settingsViewModel.settings.plugins.rtmpstreamer.overlay_file"></select>
+                                <select data-bind="options: overlay_files, value: settingsViewModel.settings.plugins.rtmpstreamer.overlay_file, valueAllowUnset: true"></select>
                                 <button class="btn btn-danger icon-trash"
                                         data-bind="enable: settingsViewModel.settings.plugins.rtmpstreamer.overlay_file() != '{{ plugin_rtmpstreamer_overlay_file_default }}', click: function() { rmImage(settingsViewModel.settings.plugins.rtmpstreamer.overlay_file()); return true; }"></button>
                             </div>

--- a/octoprint_rtmpstreamer/templates/rtmpstreamer_settings.jinja2
+++ b/octoprint_rtmpstreamer/templates/rtmpstreamer_settings.jinja2
@@ -186,40 +186,43 @@
                             </div>
                         </div>
                     </div>
-                    <div class="control-group"
+                    <div
                          data-bind="visible: settingsViewModel.settings.plugins.rtmpstreamer.use_dynamic_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.use_overlay()">
-                        <div class="controls">
-                            <label class="control-label"><input class="input-checkbox" type="checkbox"
-                                                                data-bind="checked: settingsViewModel.settings.plugins.rtmpstreamer.include_thumb" /> {{ _('Include GCode Thumbnail') }}
-                            </label>
-                            <span class="help-block">Requires the Slicer Thumbnails plugin.</span>
-                        </div>
-                    </div>
-                    <div class="control-group"
-                         data-bind="visible: settingsViewModel.settings.plugins.rtmpstreamer.use_dynamic_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.use_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.include_thumb">
-                        <label class="control-label">{{ _('Thumb Size') }}</label>
-                        <div class="controls">
-                            <div class="input-append">
-                                <input class="input-mini" type="number" min="0"
-                                       data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbw, attr: { max: $root.stream_resolution().split('x')[0] }"/>
-                                <span class="add-on">px</span>
-                                <input class="input-mini" type="number" min="0" 
-                                       data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbh, attr: { max: $root.stream_resolution().split('x')[1] }"/>
-                                <span class="add-on">px</span>
+                        <div class="control-group">
+                            <div class="controls">
+                                <label class="control-label"><input class="input-checkbox" type="checkbox"
+                                                                    data-bind="checked: settingsViewModel.settings.plugins.rtmpstreamer.include_thumb" /> {{ _('Include GCode Thumbnail') }}
+                                </label>
+                                <span class="help-block">Requires the Slicer Thumbnails plugin.</span>
                             </div>
                         </div>
-                    </div>
-                    <div class="control-group"
-                         data-bind="visible: settingsViewModel.settings.plugins.rtmpstreamer.use_dynamic_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.use_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.include_thumb">
-                        <label class="control-label">{{ _('Thumb Position') }}</label>
-                        <div class="controls">
-                            <div class="input-append">
-                                <input class="input-mini" type="number" min="0"
-                                       data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbx, attr: { max: $root.stream_resolution().split('x')[0] }"/>
-                                <span class="add-on">px</span>
-                                <input class="input-mini" type="number" min="0" 
-                                       data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumby, attr: { max: $root.stream_resolution().split('x')[1] }"/>
-                                <span class="add-on">px</span>
+                        <div
+                             data-bind="visible: settingsViewModel.settings.plugins.rtmpstreamer.include_thumb">
+                            <div class="control-group">
+                                <label class="control-label">{{ _('Thumb Size') }}</label>
+                                <div class="controls">
+                                    <div class="input-append">
+                                        <input class="input-mini" type="number" min="0"
+                                               data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbw, attr: { max: $root.stream_resolution().split('x')[0] }"/>
+                                        <span class="add-on">px</span>
+                                        <input class="input-mini" type="number" min="0" 
+                                               data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbh, attr: { max: $root.stream_resolution().split('x')[1] }"/>
+                                        <span class="add-on">px</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="control-group">
+                                <label class="control-label">{{ _('Thumb Position') }}</label>
+                                <div class="controls">
+                                    <div class="input-append">
+                                        <input class="input-mini" type="number" min="0"
+                                               data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbx, attr: { max: $root.stream_resolution().split('x')[0] }"/>
+                                        <span class="add-on">px</span>
+                                        <input class="input-mini" type="number" min="0" 
+                                               data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumby, attr: { max: $root.stream_resolution().split('x')[1] }"/>
+                                        <span class="add-on">px</span>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/octoprint_rtmpstreamer/templates/rtmpstreamer_settings.jinja2
+++ b/octoprint_rtmpstreamer/templates/rtmpstreamer_settings.jinja2
@@ -188,6 +188,43 @@
                     </div>
                     <div class="control-group"
                          data-bind="visible: settingsViewModel.settings.plugins.rtmpstreamer.use_dynamic_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.use_overlay()">
+                        <div class="controls">
+                            <label class="control-label"><input class="input-checkbox" type="checkbox"
+                                                                data-bind="checked: settingsViewModel.settings.plugins.rtmpstreamer.include_thumb" /> {{ _('Include GCode Thumbnail') }}
+                            </label>
+                            <span class="help-block">Requires the Slicer Thumbnails plugin.</span>
+                        </div>
+                    </div>
+                    <div class="control-group"
+                         data-bind="visible: settingsViewModel.settings.plugins.rtmpstreamer.use_dynamic_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.use_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.include_thumb">
+                        <label class="control-label">{{ _('Thumb Size') }}</label>
+                        <div class="controls">
+                            <div class="input-append">
+                                <input class="input-mini" type="number" min="0"
+                                       data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbw, attr: { max: $root.stream_resolution().split('x')[0] }"/>
+                                <span class="add-on">px</span>
+                                <input class="input-mini" type="number" min="0" 
+                                       data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbh, attr: { max: $root.stream_resolution().split('x')[1] }"/>
+                                <span class="add-on">px</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="control-group"
+                         data-bind="visible: settingsViewModel.settings.plugins.rtmpstreamer.use_dynamic_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.use_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.include_thumb">
+                        <label class="control-label">{{ _('Thumb Position') }}</label>
+                        <div class="controls">
+                            <div class="input-append">
+                                <input class="input-mini" type="number" min="0"
+                                       data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumbx, attr: { max: $root.stream_resolution().split('x')[0] }"/>
+                                <span class="add-on">px</span>
+                                <input class="input-mini" type="number" min="0" 
+                                       data-bind="value: settingsViewModel.settings.plugins.rtmpstreamer.thumby, attr: { max: $root.stream_resolution().split('x')[1] }"/>
+                                <span class="add-on">px</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="control-group"
+                         data-bind="visible: settingsViewModel.settings.plugins.rtmpstreamer.use_dynamic_overlay() && settingsViewModel.settings.plugins.rtmpstreamer.use_overlay()">
                         <label class="control-label">{{ _('Dynamic Setup') }}</label>
                         <div class="controls">
                             <table class="table table-striped table-condensed table-fit">


### PR DESCRIPTION
- Add an option to use the thumbnail from Silver Thumbnails plugin
- Also remove ".gcode" from the filename text

![overlay](https://user-images.githubusercontent.com/1868661/155251143-9ba1ca6e-3d77-4e9f-b16a-a00052fbb5b7.png)
