### PR TITLE
Allow plugin to pull image

### DIFF
--- a/octoprint_rtmpstreamer/templates/rtmpstreamer_settings.jinja2
+++ b/octoprint_rtmpstreamer/templates/rtmpstreamer_settings.jinja2
@@ -387,6 +387,15 @@
                         <span class="help-block">The name given to the running Docker container (default: {{ plugin_rtmpstreamer_docker_container_default | escape }}).</span>
                     </div>
                 </div>
+                <div class="control-group">
+                    <div class="controls">
+                        <label class="checkbox">
+                            <input type="checkbox"
+                                data-bind="checked: settingsViewModel.settings.plugins.rtmpstreamer.docker_pull"> Pull image if not found on server
+                        </label>
+                    </div>
+                </div>
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
It appeared a bit unnecessary to me to throw an error if the docker image isn't found on the system, if you could as well do a pull.
Added a checkbox to settings, added an on_settings_save to trigger _get_image when settings are updated and trigger _pull_image from inside _get_image if the setting is enabled.
Also changed the import docker to only importing from_env and some slightly more specific error handling, and a little bugfix where there would be an attempt to create a container if creating the Docker client did not succeed.